### PR TITLE
Bugfix: ...

### DIFF
--- a/Assets/Scripts/DialogueUI.cs
+++ b/Assets/Scripts/DialogueUI.cs
@@ -39,7 +39,7 @@ public class DialogueUI : MonoBehaviour
 			string dialogue = dialogueObject.Dialogue[i];
 			yield return _typewriterEffect.Run(dialogue, textLabel);
 
-			if (dialogueObject.IsFetchQuest)
+			if (i == dialogueObject.Dialogue.Length - 1 && dialogueObject.IsFetchQuest)
 			{
 				Prop toFetch = FindObjectsOfType<Prop>().ToList().Find(prop => prop.gameObject.name == dialogueObject.PropToFetch);
 				if (toFetch == null) Debug.LogError($"Prop \"{dialogueObject.PropToFetch}\" not found");

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -157,6 +157,10 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 11400000, guid: a224c40d7b97445fafa6f05f0ab18368, type: 2}
+  - {fileID: -1289951975280033077, guid: 8698846daab4ead42b305afc8d34bf00, type: 2}
+  - {fileID: 5493774269640829403, guid: a6b84d93439dff0469314f9436a6126d, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Wait with the fetch quest until all the dialogue entries have been shown, instead of requiring the fetch quest after the first dialogue entry